### PR TITLE
use more portable shebang line

### DIFF
--- a/PifCoSm.pl
+++ b/PifCoSm.pl
@@ -1,5 +1,6 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
+use warnings;
 use strict;
 use DBI;
 use FindBin ();


### PR DESCRIPTION
Works even when perl is in a nonstandard location (such as in a conda environment).  Already incorporated by a patch in [bioconda version](https://github.com/bioconda/bioconda-recipes/pull/30704/commits/33c2e2f22a04688ab294da5fa755a4ddde31b050).